### PR TITLE
Add pre-commit hook

### DIFF
--- a/config/pre-commit-setup/add_hook.bat
+++ b/config/pre-commit-setup/add_hook.bat
@@ -1,0 +1,23 @@
+@echo off
+SETLOCAL EnableDelayedExpansion
+
+REM Define relative path to .git/hooks
+SET "hooksDir=../../.git/hooks"
+
+REM Check if .git/hooks directory exists, if not create it
+IF NOT EXIST "!hooksDir!" (
+    mkdir "!hooksDir!"
+    echo Created directory: !hooksDir!
+)
+
+REM Check if pre-commit hook already exists
+IF EXIST "!hooksDir!/pre-commit" (
+    REM Backup existing pre-commit hook
+    copy /Y "!hooksDir!/pre-commit" "!hooksDir!/pre-commit.bak"
+    echo Existing pre-commit hook backed up to: !hooksDir!/pre-commit.bak
+)
+
+REM Copy the new pre-commit hook
+copy /Y "pre-commit" "!hooksDir!/pre-commit"
+
+echo New pre-commit hook setup complete.

--- a/config/pre-commit-setup/add_hook.sh
+++ b/config/pre-commit-setup/add_hook.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Define relative path to .git/hooks
+hooksDir="../../.git/hooks"
+
+# Check if .git/hooks directory exists, if not create it
+if [ ! -d "$hooksDir" ]; then
+    mkdir -p "$hooksDir"
+    echo "Created directory: $hooksDir"
+fi
+
+# Check if pre-commit hook already exists
+if [ -f "$hooksDir/pre-commit" ]; then
+    # Backup existing pre-commit hook
+    cp "$hooksDir/pre-commit" "$hooksDir/pre-commit.bak"
+    echo "Existing pre-commit hook backed up to: $hooksDir/pre-commit.bak"
+fi
+
+# Copy the new pre-commit hook
+cp "pre-commit" "$hooksDir/pre-commit"
+
+echo "New pre-commit hook setup complete."

--- a/config/pre-commit-setup/pre-commit
+++ b/config/pre-commit-setup/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+# @@author rertyy-reused
+# Reused from https://imnnquy.medium.com/development-team-setup-pre-commit-hook-and-check-commit-message-dd37313196e7
+
+set -e
+
+# Check style for main and test
+./gradlew checkstyleMain
+./gradlew checkstyleTest
+./gradlew test
+
+# Check the exit status from gradle command
+if [ $? -eq 0 ]; then
+  echo "Your code has been validated successfully!"
+else
+  echo "Validation failed, please check your code and try again..."
+  exit 1
+fi
+# @@author


### PR DESCRIPTION
### Add scripts to install a pre-commit hook

**To use**
Run the corresponding `.bat` or `.sh` script in `tp/config/pre-commit-setup/`.

**Rationale**
Allow errors in Gradle build to be detected without needing to push and wait for CI.

**Modifications**
To make changes to the hook, modify `config/pre-commit-setup/pre-commit` and rerun the `.bat` or `.sh` accordingly.

**Details**
The script backs up any existing `pre-commit` in `.git/hooks` to `pre-commit.bak`.
And then copies `config/pre-commit-setup/pre-commit` to `.git/hooks`.

The hook runs the following Gradle tasks and prevents commits if the tasks fail.
```
./gradlew checkstyleMain
./gradlew checkstyleTest
./gradlew test
```
Note that Gradle tasks can take a while to run, so modify the hook as required.
