### PR TITLE
Remove ./gradlew test from pre-commit setup

### DIFF
--- a/config/pre-commit-setup/pre-commit
+++ b/config/pre-commit-setup/pre-commit
@@ -7,7 +7,6 @@ set -e
 # Check style for main and test
 ./gradlew checkstyleMain
 ./gradlew checkstyleTest
-./gradlew test
 
 # Check the exit status from gradle command
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
Removed `./gradlew test` from pre-commit test

Currently included pre-commit hooks in the file:
- `./gradlew checkstyleMain`
- `./gradlew checkstyleMain`

Set/reset your local settings by by running the corresponding `.sh`/`.bat` or modifying `.git/hooks/pre-commit` accordingly.
 
More time lost from running `./gradlew test` in `pre-commit` than waiting for CI to test.
