### PR TITLE
Fix datetime toString

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -15,6 +15,7 @@ public class DateTimeUtil {
      * Returns a list of valid date time formats.
      */
     public static final String VALID_DATETIME_FORMAT = "dd-MM-yyyy HH:mm";
+
     /**
      * Returns the valid formatter pattern.
      */
@@ -33,6 +34,16 @@ public class DateTimeUtil {
             return false;
         }
         return true;
+    }
+
+    /**
+     * Returns the current date time as a String.
+     *
+     * @param dateTime the date to be formatted.
+     * @return the current date time as a String.
+     */
+    public static String formatDateTime(LocalDateTime dateTime) {
+        return dateTime.format(FORMATTER);
     }
 
     /**

--- a/src/main/java/seedu/address/model/order/Deadline.java
+++ b/src/main/java/seedu/address/model/order/Deadline.java
@@ -42,7 +42,7 @@ public class Deadline {
 
     @Override
     public String toString() {
-        return deadline.toString();
+        return DateTimeUtil.formatDateTime(deadline);
     }
 
 

--- a/src/main/java/seedu/address/model/order/OrderDate.java
+++ b/src/main/java/seedu/address/model/order/OrderDate.java
@@ -33,7 +33,7 @@ public class OrderDate {
 
     @Override
     public String toString() {
-        return orderDate.toString();
+        return DateTimeUtil.formatDateTime(orderDate);
     }
 
     @Override


### PR DESCRIPTION
Override `toString` methods of classes which use `LocalDateTime`. 

Changed from ISO time to `dd-MM-YYYY HH:MM`. This allows more consistent representation of `LocalDateTime` variables