### PR TITLE
Oop-ify AddOrder by extracting AddOrder

### DIFF
--- a/src/main/java/seedu/address/logic/commands/orders/AddOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/orders/AddOrderCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands.orders;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
 import java.util.HashSet;
 import java.util.List;
@@ -60,6 +61,7 @@ public class AddOrderCommand extends Command {
                 personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
                 personToEdit.getAddress(), personToEdit.getTags(), orders);
         model.setPerson(personToEdit, editedPerson, this.order);
+        model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);
         return new CommandResult(generateSuccessMessage(editedPerson));
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -76,6 +76,10 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.add(p);
     }
 
+    public void addOrder(Order order) {
+        persons.addOrder(order);
+    }
+
     /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
      * {@code target} must exist in the address book.

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.order.Order;
+import seedu.address.model.order.OrderList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -23,9 +24,11 @@ public class AddressBook implements ReadOnlyAddressBook {
      *   among constructors.
      */
     private final UniquePersonList persons;
+    private final OrderList orders;
 
     {
         persons = new UniquePersonList();
+        orders = new OrderList();
     }
 
     public AddressBook() {
@@ -76,9 +79,6 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.add(p);
     }
 
-    public void addOrder(Order order) {
-        persons.addOrder(order);
-    }
 
     /**
      * Replaces the given person {@code target} in the list with {@code editedPerson}.
@@ -87,8 +87,13 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
-
         persons.setPerson(target, editedPerson);
+    }
+
+    public void setPerson(Person target, Person editedPerson, Order order) {
+        requireNonNull(editedPerson);
+        orders.add(order);
+        persons.setPerson(target, editedPerson, order);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -107,11 +107,6 @@ public interface Model {
     void updateFilteredPersonList(Predicate<Person> predicate);
 
     /**
-     * Returns an unmodifiable view of the order list.
-     */
-    ObservableList<Order> getOrderList();
-
-    /**
      * Updates the filter of the filtered order list to filter by the given {@code predicate}.
      *
      * @throws NullPointerException if {@code predicate} is null.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -87,7 +87,7 @@ public interface Model {
      */
     void setPerson(Person target, Person editedPerson);
 
-    public void setPerson(Person target, Person editedPerson, Order order);
+    void setPerson(Person target, Person editedPerson, Order order);
 
     /**
      * Returns an unmodifiable view of the filtered person list.
@@ -109,7 +109,7 @@ public interface Model {
     /**
      * Returns an unmodifiable view of the order list.
      */
-    public ObservableList<Order> getOrderList();
+    ObservableList<Order> getOrderList();
 
     /**
      * Updates the filter of the filtered order list to filter by the given {@code predicate}.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -125,7 +125,6 @@ public class ModelManager implements Model {
 
     //=========== Order ================================================================================
 
-    @Override
     public ObservableList<Order> getOrderList() {
         return filteredOrders;
     }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -23,7 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
-    private final ObservableList<Order> filteredOrders;
+    private final FilteredList<Order> filteredOrders;
 
 
     /**
@@ -37,7 +37,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-        filteredOrders = this.addressBook.getOrderList();
+        filteredOrders = new FilteredList<>(this.addressBook.getOrderList());
     }
 
     public ModelManager() {
@@ -121,7 +121,7 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
-        filteredOrders.add(order);
+        addressBook.addOrder(order);
 
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -120,16 +120,14 @@ public class ModelManager implements Model {
     public void setPerson(Person target, Person editedPerson, Order order) {
         requireAllNonNull(target, editedPerson);
 
-        addressBook.setPerson(target, editedPerson);
-        addressBook.addOrder(order);
-
+        addressBook.setPerson(target, editedPerson, order);
     }
 
     //=========== Order ================================================================================
 
     @Override
     public ObservableList<Order> getOrderList() {
-        return this.addressBook.getOrderList();
+        return filteredOrders;
     }
 
     /**
@@ -144,6 +142,7 @@ public class ModelManager implements Model {
     @Override
     public void updateFilteredOrderList(Predicate<Order> predicate) {
         requireNonNull(predicate);
+        filteredOrders.setPredicate(predicate);
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -125,10 +125,6 @@ public class ModelManager implements Model {
 
     //=========== Order ================================================================================
 
-    public ObservableList<Order> getOrderList() {
-        return filteredOrders;
-    }
-
     /**
      * Returns an unmodifiable view of the list of {@code Order} backed by the internal list of.
      * {@code versionedAddressBook}

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -72,6 +72,22 @@ public class UniquePersonList implements Iterable<Person> {
         internalList.set(index, editedPerson);
     }
 
+    public void setPerson(Person target, Person editedPerson, Order order) {
+        requireAllNonNull(target, editedPerson);
+
+        int index = internalList.indexOf(target);
+        if (index == -1) {
+            throw new PersonNotFoundException();
+        }
+
+        if (!target.isSamePerson(editedPerson) && contains(editedPerson)) {
+            throw new DuplicatePersonException();
+        }
+
+        internalList.set(index, editedPerson);
+        internalOrderList.add(order);
+    }
+
     /**
      * Removes the equivalent person from the list.
      * The person must exist in the list.
@@ -99,6 +115,9 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.setAll(persons);
+        internalOrderList.setAll(asUnmodifiableObservableListOrders());
+
+
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -28,6 +28,9 @@ public class UniquePersonList implements Iterable<Person> {
     private final ObservableList<Person> internalList = FXCollections.observableArrayList();
     private final ObservableList<Person> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
+    private final ObservableList<Order> internalOrderList = FXCollections.observableArrayList();
+    private final ObservableList<Order> internalUnmodifiableOrderList =
+            FXCollections.unmodifiableObservableList(internalOrderList);
 
     /**
      * Returns true if the list contains an equivalent person as the given argument.
@@ -106,14 +109,23 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Adds an order to the list.
+     *
+     * @param order a valid order.
+     */
+    public void addOrder(Order order) {
+        requireNonNull(order);
+        internalOrderList.add(order);
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Order> asUnmodifiableObservableListOrders() {
-        ObservableList<Order> allOrders = FXCollections.observableArrayList();
         for (Person person : internalList) {
-            allOrders.addAll(person.getOrdersList());
+            internalOrderList.addAll(person.getOrdersList());
         }
-        return allOrders;
+        return internalUnmodifiableOrderList;
     }
 
     @Override

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -22,7 +22,6 @@ class JsonSerializableAddressBook {
     public static final String MESSAGE_DUPLICATE_PERSON = "Persons list contains duplicate person(s).";
 
     private final List<JsonAdaptedPerson> persons = new ArrayList<>();
-    private final List<JsonAdaptedOrder> orders = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonSerializableAddressBook} with the given persons.
@@ -39,7 +38,6 @@ class JsonSerializableAddressBook {
      */
     public JsonSerializableAddressBook(ReadOnlyAddressBook source) {
         persons.addAll(source.getPersonList().stream().map(JsonAdaptedPerson::new).collect(Collectors.toList()));
-        orders.addAll(source.getOrderList().stream().map(JsonAdaptedOrder::new).collect(Collectors.toList()));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -89,7 +89,7 @@ public class LogicManagerTest {
 
     @Test
     public void getFilteredOrderList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(IndexOutOfBoundsException.class, () -> logic.getFilteredOrderList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredOrderList().remove(0));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
@@ -144,10 +144,6 @@ public class AddOrderCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-        @Override
-        public ObservableList<Order> getOrderList() {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /**
@@ -183,8 +179,7 @@ public class AddOrderCommandTest {
             return personList;
         }
 
-        @Override
-        public ObservableList<Order> getOrderList() {
+        private ObservableList<Order> getOrderList() {
             ObservableList<Order> orderList = FXCollections.observableArrayList(this.person.getOrders());
             return orderList;
         }

--- a/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
@@ -40,7 +40,7 @@ public class AddOrderCommandTest {
 
         Index targetIndex = INDEX_FIRST_PERSON;
         CommandResult commandResult = new AddOrderCommand(targetIndex, order).execute(modelStub);
-        assertEquals(1, modelStub.getOrderList().size());
+        assertEquals(1, modelStub.getFilteredOrderList().size());
     }
 
     @Test
@@ -179,9 +179,15 @@ public class AddOrderCommandTest {
             return personList;
         }
 
-        private ObservableList<Order> getOrderList() {
+        @Override
+        public ObservableList<Order> getFilteredOrderList() {
             ObservableList<Order> orderList = FXCollections.observableArrayList(this.person.getOrders());
             return orderList;
+        }
+
+        @Override
+        public void updateFilteredOrderList(Predicate<Order> predicate) {
+            requireNonNull(predicate);
         }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteOrderCommandTest.java
@@ -193,5 +193,10 @@ public class DeleteOrderCommandTest {
             addressBook.addPerson(this.person);
             return addressBook;
         }
+
+        @Override
+        public void updateFilteredOrderList(Predicate<Order> predicate) {
+            requireNonNull(predicate);
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteOrderCommandTest.java
@@ -147,10 +147,6 @@ public class DeleteOrderCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
-        @Override
-        public ObservableList<Order> getOrderList() {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /**
@@ -186,8 +182,7 @@ public class DeleteOrderCommandTest {
             return personList;
         }
 
-        @Override
-        public ObservableList<Order> getOrderList() {
+        private ObservableList<Order> getOrderList() {
             ObservableList<Order> orderList = FXCollections.observableArrayList(this.person.getOrders());
             return orderList;
         }

--- a/src/test/java/seedu/address/logic/commands/clients/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/clients/AddCommandTest.java
@@ -171,11 +171,6 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<Order> getOrderList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
         public void updateFilteredOrderList(Predicate<Order> predicate) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -95,7 +95,7 @@ public class ModelManagerTest {
 
     @Test
     public void getOrderList_anyOrder_throwsCommandException() {
-        assertEquals(0, modelManager.getOrderList().size());
+        assertEquals(0, modelManager.getFilteredOrderList().size());
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -100,7 +100,7 @@ public class ModelManagerTest {
 
     @Test
     public void getFilteredOrderList_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(IndexOutOfBoundsException.class, () -> modelManager.getFilteredOrderList().remove(0));
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredOrderList().remove(0));
     }
 
     @Test


### PR DESCRIPTION
Changes:
Follow the OOP style similar to how `Person`s are displayed in the GUI by using `FilteredList` in `ModelManager` and using `FXCollections.unmodifiableObservableList` in `UniquePersonList`.

Using a `final` `ObservableList` prevents reinstantiation of the list which degrades performance.

Removed unnecessary `OrderList` storage within `AddressBook.json`

~~Bug:~~
~~Any command duplicates the current Orders.~~
~~Likely due to how `setPerson` is called at the same time Orders are changed.~~
Bug resolved.

Resolves part of #92