### PR TITLE
Fix nested and unecessary code

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -56,4 +56,13 @@ public class DateTimeUtil {
         return LocalDateTime.parse(dateTime, FORMATTER);
     }
 
+    /**
+     * Returns current date time as a String in the common datetime format.
+     *
+     * @return the current date time as a String.
+     */
+    public static String getCurrentTime() {
+        LocalDateTime now = LocalDateTime.now();
+        return formatDateTime(now);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/orders/AddOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/orders/AddOrderCommand.java
@@ -57,9 +57,11 @@ public class AddOrderCommand extends Command {
         Set<Order> orders = personToEdit.getOrders();
         orders = new HashSet<>(orders);
         orders.add(this.order);
+
         Person editedPerson = new Person(
                 personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
                 personToEdit.getAddress(), personToEdit.getTags(), orders);
+
         model.setPerson(personToEdit, editedPerson, this.order);
         model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);
         return new CommandResult(generateSuccessMessage(editedPerson));

--- a/src/main/java/seedu/address/logic/commands/orders/DeleteOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/orders/DeleteOrderCommand.java
@@ -43,35 +43,48 @@ public class DeleteOrderCommand extends Command {
         this.index = index;
     }
 
+
+    /**
+     * Retrieves the order from the person which matches the index.
+     *
+     * @param person Person to retrieve the order from.
+     * @return Order if found, else null.
+     */
+    private Order getOrderFromPerson(Person person) {
+        return person.getOrders().stream()
+                .filter(order -> order.checkId(this.index))
+                .findFirst()
+                .orElse(null);
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireAllNonNull(model);
+
         Order changeOrder = null;
         Person personToEdit = null;
         List<Person> personList = model.getAddressBook().getPersonList();
+
         for (Person person : personList) {
-            if (changeOrder != null) {
+            Order order = getOrderFromPerson(person);
+            if (order != null) {
+                changeOrder = order;
+                personToEdit = person;
                 break;
             }
-            if (person.getOrders() != null) {
-                Set<Order> orders = person.getOrders();
-                for (Order order : orders) {
-                    if (order.checkId(this.index)) {
-                        changeOrder = order;
-                        personToEdit = person;
-                        break;
-                    }
-                }
-            }
         }
+
         if (changeOrder == null) {
             throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
         }
+
         Person editedPerson = new Person(
                 personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
                 personToEdit.getAddress(), personToEdit.getTags(),
                 removeOrder(this.index, personToEdit.getOrders()));
+
         model.setPerson(personToEdit, editedPerson);
+
         return new CommandResult(generateSuccessMessage(editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
@@ -6,12 +6,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_BY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DETAILS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.NoSuchElementException;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.util.DateTimeUtil;
 import seedu.address.logic.commands.orders.AddOrderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.order.Amount;
@@ -26,11 +25,6 @@ import seedu.address.model.order.Status;
  * Parses input arguments and creates a new AddOrderCommand object.
  */
 public class AddOrderCommandParser implements Parser<AddOrderCommand> {
-    public static String getCurrentTime() {
-        LocalDateTime now = LocalDateTime.now();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
-        return now.format(formatter);
-    }
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddOrderCommand
@@ -51,7 +45,7 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
                     AddOrderCommand.MESSAGE_USAGE), ive);
         }
         OrderId orderId = new OrderId();
-        OrderDate orderDate = new OrderDate(getCurrentTime());
+        OrderDate orderDate = new OrderDate(DateTimeUtil.getCurrentTime());
         Deadline deadline;
         Remark remark;
         Amount amount;

--- a/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
@@ -44,6 +44,7 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddOrderCommand.MESSAGE_USAGE), ive);
         }
+
         OrderId orderId = new OrderId();
         OrderDate orderDate = new OrderDate(DateTimeUtil.getCurrentTime());
         Deadline deadline;
@@ -57,6 +58,7 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     AddOrderCommand.MESSAGE_USAGE), error);
         }
+
         Status status = new Status("pending");
         Order order = new Order(orderId, orderDate, deadline, amount, remark, status);
         return new AddOrderCommand(index, order);

--- a/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
@@ -9,6 +9,7 @@ import java.time.format.DateTimeFormatter;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.util.DateTimeUtil;
 import seedu.address.logic.commands.orders.AddOrderCommand;
 
 public class AddOrderCommandParserTest {
@@ -26,8 +27,8 @@ public class AddOrderCommandParserTest {
     public void check_sameCurrentTime_success() {
         LocalDateTime now = LocalDateTime.now();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
-        AddOrderCommandParser.getCurrentTime();
-        assertEquals(AddOrderCommandParser.getCurrentTime(), now.format(formatter));
+        DateTimeUtil.getCurrentTime();
+        assertEquals(DateTimeUtil.getCurrentTime(), now.format(formatter));
     }
 
 


### PR DESCRIPTION
General code cleanup for style and reading

Fix issues of weak SLAP and deeply nested code:
`DateTimeUtil::getCurrentTime` and `DeleteOrderCommand::getOrderFromPerson`.

Add newlines to make reading code easier.

Fixes #92 