### PR TITLE
Fix rawtype warning

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -55,7 +55,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        Set<Order> orderList = new HashSet();
+        Set<Order> orderList = new HashSet<>();
 
         Person person = new Person(name, phone, email, address, tagList, orderList);
 


### PR DESCRIPTION
Fixes a rawtype compile warning from #117 

`new HashSet()` -> `new HashSet<>()`