### PR TITLE
Modify links to point to repo

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -25,7 +25,7 @@
             {%- endif -%}
           {%- endfor -%}
           {%- if site.repository -%}
-          <a class="page-link no-hover" href="https://github.com/{{site.repository}}">
+            <a class="page-link no-hover" href="https://github.com/AY2324S2-CS2103T-T09-2/tp">
             <img src="{{site.github_icon | relative_url}}" class="icon" alt="View on GitHub">
           </a>
           {%- endif -%}

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -16,7 +16,7 @@ import seedu.address.commons.core.LogsCenter;
 public class HelpWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL =
-            "https://ay2324s2-cs2103t-t09-2.github.io/tp/";
+            "https://ay2324s2-cs2103t-t09-2.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,8 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL =
+            "https://ay2324s2-cs2103t-t09-2.github.io/tp/";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
@@ -46,21 +47,21 @@ public class HelpWindow extends UiPart<Stage> {
 
     /**
      * Shows the help window.
-     * @throws IllegalStateException
-     *     <ul>
-     *         <li>
-     *             if this method is called on a thread other than the JavaFX Application Thread.
-     *         </li>
-     *         <li>
-     *             if this method is called during animation or layout processing.
-     *         </li>
-     *         <li>
-     *             if this method is called on the primary stage.
-     *         </li>
-     *         <li>
-     *             if {@code dialogStage} is already showing.
-     *         </li>
-     *     </ul>
+     *
+     * @throws IllegalStateException <ul>
+     *                               <li>
+     *                               if this method is called on a thread other than the JavaFX Application Thread.
+     *                               </li>
+     *                               <li>
+     *                               if this method is called during animation or layout processing.
+     *                               </li>
+     *                               <li>
+     *                               if this method is called on the primary stage.
+     *                               </li>
+     *                               <li>
+     *                               if {@code dialogStage} is already showing.
+     *                               </li>
+     *                               </ul>
      */
     public void show() {
         logger.fine("Showing help page about the application.");


### PR DESCRIPTION
Website header and HelpWindow point to se-edu base repo rather than our repository. Links have been changed accordingly.

Fixes #122 

HelpWindow
![image](https://github.com/AY2324S2-CS2103T-T09-2/tp/assets/107781565/16c7db1a-a244-45a6-80f6-e770ff3a1728)

Website header from Deployment (GitHub icon)
![image](https://github.com/AY2324S2-CS2103T-T09-2/tp/assets/107781565/41802f17-1678-4207-8bc8-1ac1fc13b753)
