### PR TITLE
Use Person reference in Order

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -4,7 +4,6 @@ import java.nio.file.Path;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.util.Pair;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -41,7 +40,7 @@ public interface Logic {
     /**
      * Returns an unmodifiable view of the filtered list of orders.
      */
-    ObservableList<Pair<Person, Order>> getFilteredOrderList();
+    ObservableList<Order> getFilteredOrderList();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -8,7 +8,6 @@ import java.util.logging.Logger;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.util.Pair;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -74,7 +73,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<Pair<Person, Order>> getFilteredOrderList() {
+    public ObservableList<Order> getFilteredOrderList() {
         return model.getFilteredOrderList();
     }
 

--- a/src/main/java/seedu/address/logic/commands/orders/AddOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/orders/AddOrderCommand.java
@@ -32,7 +32,7 @@ public class AddOrderCommand extends Command {
             + "r/ [ORDER]\n"
             + "Example: " + COMMAND_WORD + " 1 d/1xRoses c/40 by/23-07-2024 00:00";
 
-    public static final String MESSAGE_SUCCESS = "New Order added!";
+    public static final String MESSAGE_SUCCESS = "New Order added! %1$s";
     public static final String MESSAGE_FAILURE = "Failed to add new Order!";
     private final Order order;
     private final Index index;
@@ -58,6 +58,7 @@ public class AddOrderCommand extends Command {
         }
         Person personToEdit = lastShownList.get(index.getZeroBased());
         Person editedPerson = getEditedPerson(personToEdit);
+        order.setPerson(editedPerson);
 
         model.setPersonAndAddOrder(personToEdit, editedPerson, this.order);
         model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);
@@ -79,6 +80,6 @@ public class AddOrderCommand extends Command {
      * {@code personToEdit}.
      */
     private String generateSuccessMessage(Person personToEdit) {
-        return String.format(MESSAGE_SUCCESS);
+        return String.format(MESSAGE_SUCCESS, personToEdit.getName());
     }
 }

--- a/src/main/java/seedu/address/logic/commands/orders/DeleteOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/orders/DeleteOrderCommand.java
@@ -50,28 +50,38 @@ public class DeleteOrderCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        List<Pair<Person, Order>> lastShownOrderList = model.getFilteredOrderList();
+        List<Order> lastShownOrderList = model.getFilteredOrderList();
 
         if (targetIndex.getZeroBased() >= lastShownOrderList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        Pair<Person, Order> personOrderPairToDelete = lastShownOrderList.get(targetIndex.getZeroBased());
-        Order orderToDelete = personOrderPairToDelete.getSecond();
-        Person person = personOrderPairToDelete.getFirst();
+        Order orderToDelete = lastShownOrderList.get(targetIndex.getZeroBased());
 
-        Person editedPerson = getEditedPerson(person, orderToDelete);
+        List<Person> personList = model.getFilteredPersonList();
+        Pair<Person, Person> pair = getEditedPerson(personList, orderToDelete);
+        Person person = pair.getFirst();
+        Person editedPerson = pair.getSecond();
 
-        model.setPersonAndDeleteOrder(person, editedPerson, personOrderPairToDelete);
+        model.setPersonAndDeleteOrder(person, editedPerson, orderToDelete);
         model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(orderToDelete)));
     }
 
-    private Person getEditedPerson(Person person, Order orderToDelete) {
-        Person editedPerson = new Person(person.getName(), person.getPhone(), person.getEmail(), person.getAddress(),
-                person.getTags(), removeOrder(orderToDelete, person.getOrders()));
-        return editedPerson;
+    private Pair<Person, Person> getEditedPerson(List<Person> personList, Order orderToDelete) throws CommandException {
+
+        for (Person person : personList) {
+            if (person.getOrders().contains(orderToDelete)) {
+                Person editedPerson = new Person(
+                        person.getName(), person.getPhone(), person.getEmail(),
+                        person.getAddress(), person.getTags(),
+                        removeOrder(orderToDelete, person.getOrders()));
+
+                return new Pair<>(person, editedPerson);
+            }
+        }
+        throw new CommandException(MESSAGE_DELETE_ORDER_FAILURE);
     }
 
     private Set<Order> removeOrder(Order orderToRemove, Set<Order> orders) {

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
-import seedu.address.commons.util.Pair;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.order.Order;
 import seedu.address.model.person.Person;
@@ -93,7 +92,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.setPersonAndAddOrder(target, editedPerson, order);
     }
 
-    public void setPersonAndDeleteOrder(Person target, Person editedPerson, Pair<Person, Order> order) {
+    public void setPersonAndDeleteOrder(Person target, Person editedPerson, Order order) {
         requireNonNull(editedPerson);
         persons.setPersonAndDeleteOrder(target, editedPerson, order);
     }
@@ -121,7 +120,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     @Override
-    public ObservableList<Pair<Person, Order>> getOrderList() {
+    public ObservableList<Order> getOrderList() {
         return persons.asUnmodifiableObservableListOrders();
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,7 +5,6 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.util.Pair;
 import seedu.address.model.order.Order;
 import seedu.address.model.person.Person;
 
@@ -22,7 +21,7 @@ public interface Model {
     /**
      * {@code Predicate} that always evaluate to true.
      */
-    Predicate<Pair<Person, Order>> PREDICATE_SHOW_ALL_ORDERS = unused -> true;
+    Predicate<Order> PREDICATE_SHOW_ALL_ORDERS = unused -> true;
 
     /**
      * Returns the user prefs.
@@ -90,7 +89,7 @@ public interface Model {
 
     void setPersonAndAddOrder(Person target, Person editedPerson, Order order);
 
-    void setPersonAndDeleteOrder(Person target, Person editedPerson, Pair<Person, Order> order);
+    void setPersonAndDeleteOrder(Person target, Person editedPerson, Order order);
 
     /**
      * Returns an unmodifiable view of the filtered person list.
@@ -100,7 +99,7 @@ public interface Model {
     /**
      * Returns an unmodifiable view of the filtered order list.
      */
-    ObservableList<Pair<Person, Order>> getFilteredOrderList();
+    ObservableList<Order> getFilteredOrderList();
 
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
@@ -114,5 +113,5 @@ public interface Model {
      *
      * @throws NullPointerException if {@code predicate} is null.
      */
-    void updateFilteredOrderList(Predicate<Pair<Person, Order>> predicate);
+    void updateFilteredOrderList(Predicate<Order> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,7 +11,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.util.Pair;
 import seedu.address.model.order.Order;
 import seedu.address.model.person.Person;
 
@@ -24,7 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
-    private final FilteredList<Pair<Person, Order>> filteredOrders;
+    private final FilteredList<Order> filteredOrders;
 
 
     /**
@@ -125,7 +124,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setPersonAndDeleteOrder(Person target, Person editedPerson, Pair<Person, Order> order) {
+    public void setPersonAndDeleteOrder(Person target, Person editedPerson, Order order) {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPersonAndDeleteOrder(target, editedPerson, order);
@@ -138,12 +137,12 @@ public class ModelManager implements Model {
      * {@code versionedAddressBook}
      */
     @Override
-    public ObservableList<Pair<Person, Order>> getFilteredOrderList() {
+    public ObservableList<Order> getFilteredOrderList() {
         return filteredOrders;
     }
 
     @Override
-    public void updateFilteredOrderList(Predicate<Pair<Person, Order>> predicate) {
+    public void updateFilteredOrderList(Predicate<Order> predicate) {
         requireNonNull(predicate);
         filteredOrders.setPredicate(predicate);
     }

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,7 +1,6 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
-import seedu.address.commons.util.Pair;
 import seedu.address.model.order.Order;
 import seedu.address.model.person.Person;
 
@@ -20,7 +19,7 @@ public interface ReadOnlyAddressBook {
      * Returns an unmodifiable view of the orders list.
      * This list will not contain any duplicate orders.
      */
-    ObservableList<Pair<Person, Order>> getOrderList();
+    ObservableList<Order> getOrderList();
 
 
 }

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -35,6 +35,21 @@ public class Order {
         this.status = status;
     }
 
+    /**
+     * Every field must be present and not null.
+     */
+    public Order(OrderId orderId, OrderDate orderDate, Deadline deadline,
+                 Price price, Remark remark, Status status, Person person) {
+        requireAllNonNull(orderId, orderDate, deadline, price, remark, status, person);
+        this.orderId = orderId;
+        this.orderDate = orderDate;
+        this.deadline = deadline;
+        this.price = price;
+        this.remark = remark;
+        this.status = status;
+        this.person = person;
+    }
+
 
     public OrderId getOrderId() {
         return orderId;
@@ -90,9 +105,7 @@ public class Order {
                 && otherOrder.getPrice().equals(getPrice())
                 && otherOrder.getRemark().equals(getRemark())
                 && otherOrder.getStatus().equals(getStatus())
-                && (otherOrder.person == null && person == null
-                || otherOrder.person != null && person != null
-                && otherOrder.person.equals(person));
+                && Objects.equals(otherOrder.getPerson(), getPerson());
 
 
     }
@@ -105,6 +118,7 @@ public class Order {
 
     @Override
     public String toString() {
+        // Intentionally do not include Person within the order to prevent infinite loop
         return new ToStringBuilder(this)
                 .add("orderId", orderId)
                 .add("orderDate", orderDate)

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -1,10 +1,12 @@
 package seedu.address.model.order;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
 
 /**
  * Represents an Order.
@@ -16,6 +18,7 @@ public class Order {
     private final Price price;
     private final Remark remark;
     private final Status status;
+    private Person person;
 
     /**
      * Every field must be present and not null.
@@ -31,6 +34,7 @@ public class Order {
         this.remark = remark;
         this.status = status;
     }
+
 
     public OrderId getOrderId() {
         return orderId;
@@ -60,6 +64,14 @@ public class Order {
         return this.getOrderId().equals(orderId);
     }
 
+    public Person getPerson() {
+        return person;
+    }
+
+    public void setPerson(Person person) {
+        requireNonNull(person);
+        this.person = person;
+    }
 
     @Override
     public boolean equals(Object other) {
@@ -77,7 +89,11 @@ public class Order {
                 && otherOrder.getDeadline().equals(getDeadline())
                 && otherOrder.getPrice().equals(getPrice())
                 && otherOrder.getRemark().equals(getRemark())
-                && otherOrder.getStatus().equals(getStatus());
+                && otherOrder.getStatus().equals(getStatus())
+                && (otherOrder.person == null && person == null
+                || otherOrder.person != null && person != null
+                && otherOrder.person.equals(person));
+
 
     }
 

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.commons.util.Pair;
 import seedu.address.model.order.Order;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
@@ -29,8 +28,8 @@ public class UniquePersonList implements Iterable<Person> {
     private final ObservableList<Person> internalList = FXCollections.observableArrayList();
     private final ObservableList<Person> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
-    private final ObservableList<Pair<Person, Order>> internalOrderList = FXCollections.observableArrayList();
-    private final ObservableList<Pair<Person, Order>> internalUnmodifiableOrderList =
+    private final ObservableList<Order> internalOrderList = FXCollections.observableArrayList();
+    private final ObservableList<Order> internalUnmodifiableOrderList =
             FXCollections.unmodifiableObservableList(internalOrderList);
 
     /**
@@ -76,13 +75,13 @@ public class UniquePersonList implements Iterable<Person> {
     /**
      * Replaces the person {@code target} in the list with {@code editedPerson}.
      *
-     * @param target            person to be removed.
-     * @param editedPerson      person to be added.
-     * @param personOrderPair   pair to be removed.
+     * @param target       person to be removed.
+     * @param editedPerson person to be added.
+     * @param order        order to be removed.
      */
-    public void setPersonAndDeleteOrder(Person target, Person editedPerson, Pair<Person, Order> personOrderPair) {
+    public void setPersonAndDeleteOrder(Person target, Person editedPerson, Order order) {
         setPerson(target, editedPerson);
-        internalOrderList.remove(personOrderPair);
+        internalOrderList.remove(order);
     }
 
 
@@ -95,7 +94,7 @@ public class UniquePersonList implements Iterable<Person> {
      */
     public void setPersonAndAddOrder(Person target, Person editedPerson, Order order) {
         setPerson(target, editedPerson);
-        internalOrderList.add(new Pair<>(editedPerson, order));
+        internalOrderList.add(order);
     }
 
     /**
@@ -141,13 +140,9 @@ public class UniquePersonList implements Iterable<Person> {
     /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
-    public ObservableList<Pair<Person, Order>> asUnmodifiableObservableListOrders() {
-        internalOrderList.clear();
+    public ObservableList<Order> asUnmodifiableObservableListOrders() {
         for (Person person : internalList) {
-            List<Order> orderSet = person.getOrdersList();
-            for (Order order : orderSet) {
-                internalOrderList.add(new Pair<>(person, order));
-            }
+            internalOrderList.addAll(person.getOrdersList());
         }
         return internalUnmodifiableOrderList;
     }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -24,6 +24,9 @@ import seedu.address.model.tag.Tag;
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
+    private SampleDataUtil() {
+    } //
+
     public static Person[] getSamplePersons() {
         Set<Order> s1 = Set.of(
                 new Order(new OrderId("69c25c8d-9e34-4d9d-8bad-e378f203ae73"),
@@ -31,22 +34,22 @@ public class SampleDataUtil {
                         new Price("50"), new Remark("No remark"), new Status("PENDING")),
                 new Order(new OrderId("b7d063c5-f803-4f75-b2ad-777ec679b75e"),
                         new OrderDate("10-02-2024 11:33"), new Deadline("14-02-2024 10:59"),
-                        new Price("20"), new Remark("No remark"), new Status("PENDING")));
-
+                        new Price("20"), new Remark("No remark"), new Status("COMPLETED")));
         Set<Order> s2 = Set.of(
                 new Order(new OrderId("fc64826c-369b-4f45-97c0-f98e2edfa006"),
                         new OrderDate("10-10-2024 01:50"), new Deadline("15-10-2024 13:50"),
                         new Price("30"), new Remark("No remark"), new Status("CANCELED")),
                 new Order(new OrderId("cd7e3cb4-c310-4692-ba68-a779f6e09d68"),
                         new OrderDate("10-02-2024 11:33"), new Deadline("14-02-2024 10:59"),
-                        new Price("20"), new Remark("No remark"), new Status("PENDING")));
-
+                        new Price("20"), new Remark("No remark"), new Status("CANCELED")));
         Person p1 = new Person(new Name("Alex Yeoh"), new Phone("87438807"),
                 new Email("alexyeoh@example.com"), new Address("Blk 30 Geylang Street 29, #06-40"),
                 getTagSet("friends"), s1);
+        p1.getOrders().forEach(order -> order.setPerson(p1));
         Person p2 = new Person(new Name("Bernice Yu"), new Phone("99272758"),
                 new Email("berniceyu@example.com"), new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                 getTagSet("colleagues", "friends"), s2);
+        p2.getOrders().forEach(order -> order.setPerson(p2));
         Person p3 = new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"),
                 new Email("charlotte@example.com"), new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
                 getTagSet("neighbours"), Set.of());

--- a/src/main/java/seedu/address/storage/JsonAdaptedOrder.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedOrder.java
@@ -99,7 +99,7 @@ public class JsonAdaptedOrder {
         if (!Price.isValidPrice(price)) {
             throw new NumberFormatException(Price.MESSAGE_CONSTRAINTS);
         }
-        final Price modelPrice = new Price(String.valueOf(price));
+        final Price modelPrice = new Price(price);
 
         if (remark == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Remark.class.getSimpleName()));

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -121,7 +121,9 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
         final Set<Order> modelOrders = new HashSet<>(personOrders);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelOrders);
+        Person newPerson = new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelOrders);
+        newPerson.getOrders().forEach(order -> order.setPerson(newPerson));
+        return newPerson;
     }
 
 }

--- a/src/main/java/seedu/address/ui/OrderCard.java
+++ b/src/main/java/seedu/address/ui/OrderCard.java
@@ -5,9 +5,7 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
-import seedu.address.commons.util.Pair;
 import seedu.address.model.order.Order;
-import seedu.address.model.person.Person;
 
 /**
  * An UI component that displays information of a {@code Person}.
@@ -25,7 +23,6 @@ public class OrderCard extends UiPart<Region> {
      */
 
     public final Order order;
-    public final Person person;
 
     @FXML
     private HBox cardPane;
@@ -35,8 +32,6 @@ public class OrderCard extends UiPart<Region> {
     private Label id;
     @FXML
     private Label orderId;
-    @FXML
-    private Label orderClientName;
     @FXML
     private Label orderDate;
     @FXML
@@ -53,13 +48,11 @@ public class OrderCard extends UiPart<Region> {
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
-    public OrderCard(Pair<Person, Order> personOrderPair, int displayedIndex) {
+    public OrderCard(Order order, int displayedIndex) {
         super(FXML);
-        this.person = personOrderPair.getFirst();
-        this.order = personOrderPair.getSecond();
+        this.order = order;
         id.setText(displayedIndex + ". ");
         orderId.setText("OrderId: " + order.getOrderId().toString());
-        orderClientName.setText("Order Customer: " + person.getName().toString());
         orderDate.setText("Date: " + order.getOrderDate().toString());
         deadline.setText("Deadline: " + order.getDeadline().toString());
         price.setText("Price: " + order.getPrice().toString());

--- a/src/main/java/seedu/address/ui/OrderCard.java
+++ b/src/main/java/seedu/address/ui/OrderCard.java
@@ -31,6 +31,8 @@ public class OrderCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
+    private Label clientName;
+    @FXML
     private Label orderId;
     @FXML
     private Label orderDate;
@@ -53,6 +55,7 @@ public class OrderCard extends UiPart<Region> {
         this.order = order;
         id.setText(displayedIndex + ". ");
         orderId.setText("OrderId: " + order.getOrderId().toString());
+        clientName.setText("Client Name: " + order.getPerson().getName().toString());
         orderDate.setText("Date: " + order.getOrderDate().toString());
         deadline.setText("Deadline: " + order.getDeadline().toString());
         price.setText("Price: " + order.getPrice().toString());

--- a/src/main/java/seedu/address/ui/OrderListPanel.java
+++ b/src/main/java/seedu/address/ui/OrderListPanel.java
@@ -8,9 +8,7 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.commons.util.Pair;
 import seedu.address.model.order.Order;
-import seedu.address.model.person.Person;
 
 /**
  * Panel containing the list of orders.
@@ -20,24 +18,24 @@ public class OrderListPanel extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(OrderListPanel.class);
 
     @FXML
-    private ListView<Pair<Person, Order>> personOrderListView;
+    private ListView<Order> orderListView;
 
 
     /**
      * Creates a {@code OrderListPanel} with the given {@code ObservableList}.
      */
-    public OrderListPanel(ObservableList<Pair<Person, Order>> personOrderList) {
+    public OrderListPanel(ObservableList<Order> orderList) {
         super(FXML);
-        personOrderListView.setItems(personOrderList);
-        personOrderListView.setCellFactory(listView -> new OrderListViewCell());
+        orderListView.setItems(orderList);
+        orderListView.setCellFactory(listView -> new OrderListViewCell());
     }
 
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Order} using a {@code OrderCard}.
      */
-    class OrderListViewCell extends ListCell<Pair<Person, Order>> {
+    class OrderListViewCell extends ListCell<Order> {
         @Override
-        protected void updateItem(Pair<Person, Order> order, boolean empty) {
+        protected void updateItem(Order order, boolean empty) {
             super.updateItem(order, empty);
 
             if (empty || order == null) {

--- a/src/main/resources/view/OrderListCard.fxml
+++ b/src/main/resources/view/OrderListCard.fxml
@@ -21,6 +21,7 @@
                 </Label>
                 <Label fx:id="orderId" text="\$first" styleClass="cell_big_label"/>
             </HBox>
+            <Label fx:id="clientName" styleClass="cell_small_label" text="\$clientName"/>
             <Label fx:id="orderDate" styleClass="cell_small_label" text="\$orderDate"/>
             <Label fx:id="deadline" styleClass="cell_small_label" text="\$deadline"/>
             <Label fx:id="price" styleClass="cell_small_label" text="\$price"/>

--- a/src/main/resources/view/OrderListCard.fxml
+++ b/src/main/resources/view/OrderListCard.fxml
@@ -21,7 +21,6 @@
                 </Label>
                 <Label fx:id="orderId" text="\$first" styleClass="cell_big_label"/>
             </HBox>
-            <Label fx:id="orderClientName" styleClass="cell_small_label" text="\$orderClientName"/>
             <Label fx:id="orderDate" styleClass="cell_small_label" text="\$orderDate"/>
             <Label fx:id="deadline" styleClass="cell_small_label" text="\$deadline"/>
             <Label fx:id="price" styleClass="cell_small_label" text="\$price"/>

--- a/src/main/resources/view/OrderListPanel.fxml
+++ b/src/main/resources/view/OrderListPanel.fxml
@@ -3,5 +3,5 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 <VBox xmlns:fx="http://javafx.com/fxml/1" xmlns="http://javafx.com/javafx/17">
-    <ListView fx:id="personOrderListView" VBox.vgrow="ALWAYS"/>
+    <ListView fx:id="orderListView" VBox.vgrow="ALWAYS"/>
 </VBox>

--- a/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddOrderCommandTest.java
@@ -18,7 +18,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.Pair;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.orders.AddOrderCommand;
 import seedu.address.model.Model;
@@ -126,7 +125,7 @@ public class AddOrderCommandTest {
         }
 
         @Override
-        public void setPersonAndDeleteOrder(Person target, Person editedPerson, Pair<Person, Order> order) {
+        public void setPersonAndDeleteOrder(Person target, Person editedPerson, Order order) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -136,7 +135,7 @@ public class AddOrderCommandTest {
         }
 
         @Override
-        public ObservableList<Pair<Person, Order>> getFilteredOrderList() {
+        public ObservableList<Order> getFilteredOrderList() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -146,7 +145,7 @@ public class AddOrderCommandTest {
         }
 
         @Override
-        public void updateFilteredOrderList(Predicate<Pair<Person, Order>> predicate) {
+        public void updateFilteredOrderList(Predicate<Order> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -186,17 +185,13 @@ public class AddOrderCommandTest {
         }
 
         @Override
-        public ObservableList<Pair<Person, Order>> getFilteredOrderList() {
-            ObservableList<Pair<Person, Order>> personOrderList = FXCollections.observableArrayList();
-            List<Order> orderList = FXCollections.observableArrayList(this.person.getOrders());
-            for (Order order : orderList) {
-                personOrderList.add(new Pair<>(this.person, order));
-            }
-            return personOrderList;
+        public ObservableList<Order> getFilteredOrderList() {
+            ObservableList<Order> orderList = FXCollections.observableArrayList(this.person.getOrders());
+            return orderList;
         }
 
         @Override
-        public void updateFilteredOrderList(Predicate<Pair<Person, Order>> predicate) {
+        public void updateFilteredOrderList(Predicate<Order> predicate) {
             requireNonNull(predicate);
         }
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.clients.EditCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.order.OrderNameContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -133,13 +134,12 @@ public class CommandTestUtil {
      */
     public static void showOrderAtIndex(Model model, Index targetIndex) {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredPersonList().size());
-        /* TODO FIX THIS TO FIX
+
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
         model.updateFilteredOrderList(new OrderNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredOrderList().size());
-        */
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteOrderCommandTest.java
@@ -16,7 +16,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.util.Pair;
 import seedu.address.logic.commands.orders.AddOrderCommand;
 import seedu.address.logic.commands.orders.DeleteOrderCommand;
 import seedu.address.model.AddressBook;
@@ -130,7 +129,7 @@ public class DeleteOrderCommandTest {
         }
 
         @Override
-        public void setPersonAndDeleteOrder(Person target, Person editedPerson, Pair<Person, Order> order) {
+        public void setPersonAndDeleteOrder(Person target, Person editedPerson, Order order) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -140,7 +139,7 @@ public class DeleteOrderCommandTest {
         }
 
         @Override
-        public ObservableList<Pair<Person, Order>> getFilteredOrderList() {
+        public ObservableList<Order> getFilteredOrderList() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -150,7 +149,7 @@ public class DeleteOrderCommandTest {
         }
 
         @Override
-        public void updateFilteredOrderList(Predicate<Pair<Person, Order>> predicate) {
+        public void updateFilteredOrderList(Predicate<Order> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -182,7 +181,7 @@ public class DeleteOrderCommandTest {
         }
 
         @Override
-        public void setPersonAndDeleteOrder(Person target, Person editedPerson, Pair<Person, Order> order) {
+        public void setPersonAndDeleteOrder(Person target, Person editedPerson, Order order) {
             requireAllNonNull(target, editedPerson, order);
             this.person = editedPerson;
         }
@@ -196,10 +195,11 @@ public class DeleteOrderCommandTest {
         }
 
         @Override
-        public ObservableList<Pair<Person, Order>> getFilteredOrderList() {
-            ObservableList<Pair<Person, Order>> personOrderList = FXCollections.observableArrayList();
-            personOrderList.add(new Pair<>(this.person, this.order));
-            return personOrderList;
+        public ObservableList<Order> getFilteredOrderList() {
+            List<Order> sampleList = new ArrayList<>();
+            sampleList.add(this.order);
+            ObservableList<Order> orderList = FXCollections.observableArrayList(sampleList);
+            return orderList;
         }
 
         private ObservableList<Order> getOrderList() {
@@ -215,7 +215,7 @@ public class DeleteOrderCommandTest {
         }
 
         @Override
-        public void updateFilteredOrderList(Predicate<Pair<Person, Order>> predicate) {
+        public void updateFilteredOrderList(Predicate<Order> predicate) {
             requireNonNull(predicate);
         }
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteOrderCommandTest.java
@@ -3,7 +3,8 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
-import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ORDER;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.orders.AddOrderCommand;
 import seedu.address.logic.commands.orders.DeleteOrderCommand;
 import seedu.address.model.AddressBook;
@@ -23,7 +24,6 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.order.Order;
-import seedu.address.model.order.OrderId;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.OrderBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -37,9 +37,8 @@ public class DeleteOrderCommandTest {
         OrderBuilder builder = new OrderBuilder();
         Order order = builder.build();
         ModelStubDeletingOrder modelStub = new ModelStubDeletingOrder(order, person);
-        Index targetIndex = INDEX_FIRST_PERSON;
-        CommandResult commandResult = new AddOrderCommand(targetIndex, order).execute(modelStub);
-        commandResult = new DeleteOrderCommand(targetIndex).execute(modelStub);
+        CommandResult commandResult = new AddOrderCommand(INDEX_FIRST_ORDER, order).execute(modelStub);
+        commandResult = new DeleteOrderCommand(INDEX_FIRST_ORDER).execute(modelStub);
         assertEquals(0, modelStub.getOrderList().size());
     }
 
@@ -50,12 +49,7 @@ public class DeleteOrderCommandTest {
         OrderBuilder builder = new OrderBuilder();
         Order order = builder.build();
         ModelStubDeletingOrder modelStub = new ModelStubDeletingOrder(order, person);
-        Index targetIndex = INDEX_FIRST_PERSON;
-        CommandResult commandResult = new AddOrderCommand(targetIndex, order).execute(modelStub);
-        OrderId invalidId = new OrderId();
-        // TODO fix
-        // assertThrows(CommandException.class, () -> new DeleteOrderCommand(invalidId).execute(modelStub));
-        // assertThrows(CommandException.class, () -> new DeleteOrderCommand(INDEX_FIRST_PERSON).execute(modelStub));
+        assertThrows(CommandException.class, () -> new DeleteOrderCommand(INDEX_FIRST_ORDER).execute(modelStub));
 
     }
 

--- a/src/test/java/seedu/address/logic/commands/clients/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/clients/AddCommandTest.java
@@ -15,7 +15,6 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.util.Pair;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -156,7 +155,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void setPersonAndDeleteOrder(Person target, Person editedPerson, Pair<Person, Order> order) {
+        public void setPersonAndDeleteOrder(Person target, Person editedPerson, Order order) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -166,7 +165,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<Pair<Person, Order>> getFilteredOrderList() {
+        public ObservableList<Order> getFilteredOrderList() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -176,7 +175,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updateFilteredOrderList(Predicate<Pair<Person, Order>> predicate) {
+        public void updateFilteredOrderList(Predicate<Order> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import seedu.address.commons.util.Pair;
 import seedu.address.model.order.Order;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
@@ -86,15 +85,6 @@ public class AddressBookTest {
     }
 
     @Test
-    public void equals_sameObject_returnsTrue() {
-        assertTrue(addressBook.equals(addressBook));
-    }
-    @Test
-    public void equals_nullObject_returnsFalse() {
-        assertFalse(addressBook.equals(null));
-    }
-
-    @Test
     public void toStringMethod() {
         String expected = AddressBook.class.getCanonicalName() + "{persons=" + addressBook.getPersonList() + "}";
         assertEquals(expected, addressBook.toString());
@@ -117,15 +107,10 @@ public class AddressBookTest {
         }
 
         @Override
-        public ObservableList<Pair<Person, Order>> getOrderList() {
-            ObservableList<Pair<Person, Order>> personOrderList = FXCollections.observableArrayList();
-            for (Person person : persons) {
-                List<Order> orderList = person.getOrdersList();
-                for (Order order : orderList) {
-                    personOrderList.add(new Pair<>(person, order));
-                }
-            }
-            return personOrderList;
+        public ObservableList<Order> getOrderList() {
+            return orders;
         }
+
     }
+
 }

--- a/src/test/java/seedu/address/model/order/OrderTest.java
+++ b/src/test/java/seedu/address/model/order/OrderTest.java
@@ -8,6 +8,7 @@ import static seedu.address.testutil.TypicalOrders.ROSES;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.OrderBuilder;
+import seedu.address.testutil.TypicalPersons;
 
 class OrderTest {
     @Test
@@ -29,6 +30,8 @@ class OrderTest {
 
         // EditedRoses
         Order editedRoses;
+
+        Order nullRoses;
 
         // different price -> returns false
         editedRoses = new OrderBuilder(ROSES).withPrice("200").build();
@@ -62,6 +65,12 @@ class OrderTest {
         // different orderId -> returns false
         editedRoses = new OrderBuilder(ROSES)
                 .withOrderId("434d72c4-f045-448c-84a7-6d70704e9730")
+                .build();
+        assertNotEquals(ROSES, editedRoses);
+
+        // different person -> returns false
+        editedRoses = new OrderBuilder(ROSES)
+                .withPerson(TypicalPersons.CARL)
                 .build();
         assertNotEquals(ROSES, editedRoses);
 

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -11,16 +11,12 @@ import static seedu.address.testutil.TypicalPersons.BOB;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.order.Order;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
-import seedu.address.testutil.OrderBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 public class UniquePersonListTest {
@@ -173,58 +169,7 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPersonAndAddOrder_newOrder_success() {
-        PersonBuilder personBuilder = new PersonBuilder();
-        OrderBuilder orderBuilder = new OrderBuilder();
-        Person person = personBuilder.build();
-        Order order = orderBuilder.build();
-        uniquePersonList.add(person);
-        Person editedPerson = getEditedPersonAddOrder(person, order);
-        uniquePersonList.setPersonAndAddOrder(person, editedPerson, order);
-        assertEquals(1, uniquePersonList.asUnmodifiableObservableListOrders().size());
-    }
-
-    @Test
-    public void setPersonAndDeleteOrder_removeOrder_success() {
-        PersonBuilder personBuilder = new PersonBuilder();
-        OrderBuilder orderBuilder = new OrderBuilder();
-        Person person = personBuilder.build();
-        Order order = orderBuilder.build();
-        uniquePersonList.add(person);
-        Person editedPerson = getEditedPersonAddOrder(person, order);
-        uniquePersonList.setPersonAndAddOrder(person, editedPerson, order);
-        uniquePersonList.setPersonAndDeleteOrder(editedPerson, person,
-                uniquePersonList.asUnmodifiableObservableListOrders().get(0));
-        assertEquals(0, uniquePersonList.asUnmodifiableObservableListOrders().size());
-    }
-
-    @Test
-    public void equalsMethod_sameObject_success() {
-        assertTrue(uniquePersonList.equals(uniquePersonList));
-    }
-
-    @Test
-    public void equalsMethod_nullObject_failure() {
-        assertFalse(uniquePersonList.equals(null));
-    }
-
-    @Test
-    public void checkHashCodeMethod_emptyList_success() {
-        UniquePersonList uniquePersonList2 = new UniquePersonList();
-        assertTrue(uniquePersonList2.hashCode() == uniquePersonList.hashCode());
-    }
-
-    @Test
     public void toStringMethod() {
         assertEquals(uniquePersonList.asUnmodifiableObservableList().toString(), uniquePersonList.toString());
-    }
-
-    private Person getEditedPersonAddOrder(Person person, Order order) {
-        Set<Order> orders = person.getOrders();
-        orders = new HashSet<>(orders);
-        orders.add(order);
-        return new Person(
-                person.getName(), person.getPhone(), person.getEmail(),
-                person.getAddress(), person.getTags(), orders);
     }
 }

--- a/src/test/java/seedu/address/testutil/OrderBuilder.java
+++ b/src/test/java/seedu/address/testutil/OrderBuilder.java
@@ -8,6 +8,7 @@ import seedu.address.model.order.OrderId;
 import seedu.address.model.order.Price;
 import seedu.address.model.order.Remark;
 import seedu.address.model.order.Status;
+import seedu.address.model.person.Person;
 
 /**
  * A utility class to help with building Order objects.
@@ -28,6 +29,7 @@ public class OrderBuilder {
     private Price price;
     private Remark remark;
     private Status status;
+    private Person person;
 
 
     /**
@@ -40,6 +42,7 @@ public class OrderBuilder {
         price = new Price(DEFAULT_PRICE);
         remark = new Remark(DEFAULT_REMARK);
         status = new Status(DEFAULT_STATUS);
+        person = new PersonBuilder().build();
     }
 
     /**
@@ -52,6 +55,7 @@ public class OrderBuilder {
         price = orderToCopy.getPrice();
         remark = orderToCopy.getRemark();
         status = orderToCopy.getStatus();
+        person = orderToCopy.getPerson();
     }
 
     /**
@@ -102,9 +106,20 @@ public class OrderBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Person} of the {@code Order} that we are building.
+     */
+    public OrderBuilder withPerson(Person person) {
+        this.person = person;
+        return this;
+    }
 
+
+    /**
+     * Builds the Order object.
+     */
     public Order build() {
-        return new Order(orderId, orderDate, deadline, price, remark, status);
+        return new Order(orderId, orderDate, deadline, price, remark, status, person);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalOrders.java
+++ b/src/test/java/seedu/address/testutil/TypicalOrders.java
@@ -13,6 +13,7 @@ public class TypicalOrders {
             .withPrice("10")
             .withRemark("No remark")
             .withStatus("CANCELED")
+            .withPerson(TypicalPersons.ALICE)
             .build();
     public static final Order LILIES = new OrderBuilder()
             .withOrderId("69c25c8d-9e34-4d9d-8bad-e378f203ae74")
@@ -21,6 +22,7 @@ public class TypicalOrders {
             .withPrice("10")
             .withRemark("Important")
             .withStatus("PENDING")
+            .withPerson(TypicalPersons.BOB)
             .build();
 
     private TypicalOrders() {


### PR DESCRIPTION
This PR reverts #130 and uses another method to link `Person` -> `Order` and `Order` -> `Person`, which is necessary for the GUI.

Instead of using `Pair<<Person, Order>>` everywhere, use
circular references. This allows for simpler code logic.

TODO:
Check if circular references are a problem. From preliminary testing,
add and delete do not appear to have problems.
