### PR TITLE
Sort Orders as they are added

### DIFF
--- a/src/main/java/seedu/address/logic/commands/orders/AddOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/orders/AddOrderCommand.java
@@ -4,9 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
@@ -57,23 +55,13 @@ public class AddOrderCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = getEditedPerson(personToEdit);
+        Person editedPerson = personToEdit.addOrder(order);
         order.setPerson(editedPerson);
 
         model.setPersonAndAddOrder(personToEdit, editedPerson, this.order);
         model.updateFilteredOrderList(PREDICATE_SHOW_ALL_ORDERS);
         return new CommandResult(generateSuccessMessage(editedPerson));
     }
-
-    private Person getEditedPerson(Person person) {
-        Set<Order> orders = person.getOrders();
-        orders = new HashSet<>(orders);
-        orders.add(this.order);
-        return new Person(
-                person.getName(), person.getPhone(), person.getEmail(),
-                person.getAddress(), person.getTags(), orders);
-    }
-
     /**
      * Generates a command execution success message based on whether
      * the order is added to or removed from

--- a/src/main/java/seedu/address/model/order/Deadline.java
+++ b/src/main/java/seedu/address/model/order/Deadline.java
@@ -11,7 +11,7 @@ import seedu.address.commons.util.DateTimeUtil;
  * Represents a Deadline that an order must be fulfilled
  * Guarantees: immutable; is valid as declared in {@link #isValidDeadline(String)}.
  */
-public class Deadline {
+public class Deadline implements Comparable<Deadline> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "A deadline should be in the format of "
@@ -39,6 +39,10 @@ public class Deadline {
         return DateTimeUtil.isValidDate(test);
     }
 
+    @Override
+    public int compareTo(Deadline other) {
+        return this.deadline.compareTo(other.deadline);
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -77,6 +77,18 @@ public class Person {
     }
 
     /**
+     * Returns a new Person object, with the specified Order added to the orders object.
+     *
+     * @param order the order to be added
+     * @return new Person object
+     */
+    public Person addOrder(Order order) {
+        Set<Order> newOrders = new HashSet<>(orders);
+        newOrders.add(order);
+        return new Person(this.name, this.phone, this.email, this.address, this.getTags(), newOrders);
+    }
+
+    /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.
      */

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -95,6 +95,8 @@ public class UniquePersonList implements Iterable<Person> {
     public void setPersonAndAddOrder(Person target, Person editedPerson, Order order) {
         setPerson(target, editedPerson);
         internalOrderList.add(order);
+        FXCollections.sort(internalOrderList, (order1, order2) ->
+                order1.getDeadline().compareTo(order2.getDeadline()));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class UniquePersonList implements Iterable<Person> {
     private final ObservableList<Person> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
     private final ObservableList<Order> internalOrderList = FXCollections.observableArrayList();
-    private final ObservableList<Order> internalUnmodifiableOrderList =
+    private final ObservableList<Order> internalUnmodifiableListOrder =
             FXCollections.unmodifiableObservableList(internalOrderList);
 
     /**
@@ -127,7 +128,7 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.setAll(persons);
-        internalOrderList.setAll(asUnmodifiableObservableListOrders());
+        setOrders();
     }
 
 
@@ -143,10 +144,15 @@ public class UniquePersonList implements Iterable<Person> {
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Order> asUnmodifiableObservableListOrders() {
+        return internalUnmodifiableListOrder;
+    }
+
+    private void setOrders() {
+        List<Order> creationOrderList = new ArrayList<>();
         for (Person person : internalList) {
-            internalOrderList.addAll(person.getOrdersList());
+            creationOrderList.addAll(person.getOrdersList());
         }
-        return internalUnmodifiableOrderList;
+        internalOrderList.setAll(creationOrderList);
     }
 
     @Override

--- a/src/test/java/seedu/address/model/order/DeadlineTest.java
+++ b/src/test/java/seedu/address/model/order/DeadlineTest.java
@@ -40,6 +40,20 @@ class DeadlineTest {
     }
 
     @Test
+    public void compareDeadline() {
+        Deadline deadline = new Deadline("01-01-2024 00:00");
+
+        // smaller values -> returns 1
+        assertEquals(1, deadline.compareTo(new Deadline("01-01-2023 00:00")));
+
+        // bigger values -> returns -1
+        assertEquals(-1, deadline.compareTo(new Deadline("01-01-2024 01:00")));
+
+        // same values -> returns 0
+        assertEquals(0, deadline.compareTo(new Deadline("01-01-2024 00:00")));
+    }
+
+    @Test
     public void equals() {
         Deadline deadline = new Deadline("11-05-2024 21:51");
 

--- a/src/test/java/seedu/address/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/address/model/person/UniquePersonListTest.java
@@ -15,8 +15,10 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.order.Order;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.testutil.OrderBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 public class UniquePersonListTest {
@@ -128,6 +130,27 @@ public class UniquePersonListTest {
     }
 
     @Test
+    public void addOrder_existingPerson_addOrder() {
+        Order order = new OrderBuilder().build();
+        Person person = new PersonBuilder().build();
+        uniquePersonList.add(person);
+        Person editedPerson = person.addOrder(order);
+        uniquePersonList.setPersonAndAddOrder(person, editedPerson, order);
+        assertEquals(1, uniquePersonList.asUnmodifiableObservableListOrders().size());
+    }
+
+    @Test
+    public void removeOrder_existingPersonAndOrder_removeOrder() {
+        Order order = new OrderBuilder().build();
+        Person person = new PersonBuilder().build();
+        uniquePersonList.add(person);
+        Person editedPerson = person.addOrder(order);
+        uniquePersonList.setPersonAndAddOrder(person, editedPerson, order);
+        uniquePersonList.setPersonAndDeleteOrder(editedPerson, person, order);
+        assertEquals(0, uniquePersonList.asUnmodifiableObservableListOrders().size());
+    }
+
+    @Test
     public void setPersons_nullUniquePersonList_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniquePersonList.setPersons((UniquePersonList) null));
     }
@@ -171,5 +194,13 @@ public class UniquePersonListTest {
     @Test
     public void toStringMethod() {
         assertEquals(uniquePersonList.asUnmodifiableObservableList().toString(), uniquePersonList.toString());
+    }
+
+    @Test
+    public void equals() {
+        assertTrue(uniquePersonList.equals(uniquePersonList));
+        UniquePersonList uniquePersonList2 = new UniquePersonList();
+        uniquePersonList2.add(new PersonBuilder().build());
+        assertFalse(uniquePersonList.equals(uniquePersonList2));
     }
 }


### PR DESCRIPTION
The orders are not sorted chronologically.

This may confuse users or make the application hard for them to check for deadline.

Add sort command whenever an Order is added.

This will ensure the entire Order list stays sorted.