### PR TITLE
Parser cannot parse spaces in phone number

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -64,7 +64,7 @@ public class ParserUtil {
      */
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
-        String trimmedPhone = phone.trim();
+        String trimmedPhone = phone.replaceAll("\\s+", "");
         if (!Phone.isValidPhone(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }


### PR DESCRIPTION
The parser is unable to remove spaces in between numbers in the phone number field.

This may cause inconvenience to some users who prefer to enter their numbers with a spacing.

Edit Parser to remove all spaces in the phone parse.

This will allow users to include spaces in their phone number.

Resolves #187