### PR TITLE
Fix UserGuide header

### DIFF
--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -288,7 +288,7 @@ table {
     text-align: center;
   }
   .site-header:before {
-    content: "AB-3";
+    content: "BookKeeper";
     font-size: 32px;
   }
 }


### PR DESCRIPTION
The userguide header was not updated.

User's were confused when refering to it.

Update the UserGuide header to our application name.

This will ensure that users know they are on the correct userguide.

Resolves #206 
Resolves #209 