### PR TITLE
Fix Price display and values

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
@@ -9,7 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PRICE;
 import java.util.NoSuchElementException;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.DateTimeUtil;
 import seedu.address.logic.commands.orders.AddOrderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -38,29 +37,20 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
                 PREFIX_DETAILS, PREFIX_BY, PREFIX_PRICE);
 
         Index index;
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddOrderCommand.MESSAGE_USAGE), ive);
-        }
-
-        OrderId orderId = new OrderId();
         OrderDate orderDate = new OrderDate(DateTimeUtil.getCurrentTime());
         Deadline deadline;
         Remark remark;
         Price price;
         try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            price = ParserUtil.parsePrice(argMultimap.getValue(PREFIX_PRICE).get());
             deadline = new Deadline(argMultimap.getValue(PREFIX_BY).get());
             remark = new Remark(argMultimap.getValue(PREFIX_DETAILS).get());
-            price = new Price(argMultimap.getValue(PREFIX_PRICE).get());
         } catch (NoSuchElementException error) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddOrderCommand.MESSAGE_USAGE), error);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE),
+                    error);
         }
-
-        Status status = new Status("pending");
-        Order order = new Order(orderId, orderDate, deadline, price, remark, status);
+        Order order = new Order(new OrderId(), orderDate, deadline, price, remark, new Status("pending"));
         return new AddOrderCommand(index, order);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -168,7 +168,7 @@ public class ParserUtil {
      */
     public static Price parsePrice(String price) throws ParseException {
         requireNonNull(price);
-        String trimmedPrice = price.trim();
+        String trimmedPrice = price.replaceAll("\\s+", "");
         if (!Price.isValidPrice(trimmedPrice)) {
             throw new ParseException(Price.MESSAGE_CONSTRAINTS);
         } else {

--- a/src/main/java/seedu/address/model/order/Price.java
+++ b/src/main/java/seedu/address/model/order/Price.java
@@ -34,7 +34,7 @@ public class Price {
      * @return true if the price is valid
      */
     public static boolean isValidPrice(String test) {
-        return Double.parseDouble(test) > 0;
+        return Double.parseDouble(test) >= 0;
     }
 
     /**
@@ -50,7 +50,7 @@ public class Price {
 
     @Override
     public String toString() {
-        return String.valueOf(value);
+        return String.format("%.2f", value);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/order/Price.java
+++ b/src/main/java/seedu/address/model/order/Price.java
@@ -13,7 +13,8 @@ import java.text.DecimalFormat;
 public class Price {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Price must be a positive number and can only include up to two decimal places";
+            "Price must either be 0 or a positive number. Note that any decimals after the second decimal place will "
+                    + "be rounded up.";
     public final double value;
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
@@ -16,11 +16,9 @@ public class AddOrderCommandParserTest {
     private AddOrderCommandParser parser = new AddOrderCommandParser();
 
     @Test
-    public void parse_missingPrefix_throwsParseException() {
-        final String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE);
-        assertParseFailure(parser, "1", expectedMessage);
-
-        assertParseFailure(parser, "abc", expectedMessage);
+    public void parse_missingPrefixUserIndex_throwsParseException() {
+        assertParseFailure(parser, "1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "abc", ParserUtil.MESSAGE_INVALID_INDEX);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/order/PriceTest.java
+++ b/src/test/java/seedu/address/model/order/PriceTest.java
@@ -29,12 +29,6 @@ class PriceTest {
     }
 
     @Test
-    void constructor_invalidPriceZero_throwsIllegalArgumentException() {
-        String invalidPrice = "0";
-        assertThrows(IllegalArgumentException.class, () -> new Price(invalidPrice));
-    }
-
-    @Test
     void isValidPrice() {
 
         assertThrows(NullPointerException.class, () -> Price.isValidPrice(null));
@@ -43,7 +37,7 @@ class PriceTest {
         assertFalse(Price.isValidPrice("-1"));
 
         assertThrows(NumberFormatException.class, () -> Price.isValidPrice(" "));
-        assertFalse(Price.isValidPrice("0"));
+        assertTrue(Price.isValidPrice("0"));
 
         assertTrue(Price.isValidPrice("1"));
         assertTrue(Price.isValidPrice("100"));

--- a/src/test/java/seedu/address/storage/JsonAdaptedOrderTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedOrderTest.java
@@ -18,7 +18,7 @@ public class JsonAdaptedOrderTest {
     private static final String INVALID_ORDERID = "";
     private static final String INVALID_ORDERDATE = "41-15-2024 21:51";
     private static final String INVALID_DEADLINE = "41-15-2024 21:51";
-    private static final String INVALID_PRICE = "0";
+    private static final String INVALID_PRICE = "-1";
     private static final String INVALID_REMARK = "";
     private static final String INVALID_STATUS = "invalid";
     private static final String VALID_ORDERID = "69c25c8d-9e34-4d9d-8bad-e378f203ae73";


### PR DESCRIPTION
The Price threshold was above 0, meaning that orders could not be 0. 
Additionally, the decimal places were not displayed to 2 decimal place.

User are confused and unable to give free orders to their loyal 
customers, and their decimal points would not display properly. 
Additionally, one user reported that the value 0 will crash the app.

Fix the Price object by formatting the toString method to format 
in 2 decimal places regardless of value, and allow 0 to be an 
accepted value.

This will fix the users that the users experienced, and prevent the 
application from crashing.

Resolves #152 
Resolves #163 
