### PR TITLE
Add missing DateTimeUtil test class

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateTimeUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateTimeUtil.java
@@ -3,23 +3,31 @@ package seedu.address.commons.util;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.time.format.ResolverStyle;
 
 /**
  * Helper functions for handling datetimes.
  */
 public class DateTimeUtil {
 
-
     public static final String MESSAGE_CONSTRAINTS = "Date should be in the format of dd/MM/yyyy";
+
     /**
      * Returns a list of valid date time formats.
+     * Note that ResolverStyle.STRICT requires "uuuu" instead of "yyyy"
      */
-    public static final String VALID_DATETIME_FORMAT = "dd-MM-yyyy HH:mm";
+    public static final String VALID_DATETIME_FORMAT = "dd-MM-uuuu HH:mm";
 
     /**
      * Returns the valid formatter pattern.
      */
-    public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(VALID_DATETIME_FORMAT);
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter
+            .ofPattern(VALID_DATETIME_FORMAT)
+            .withResolverStyle(ResolverStyle.STRICT);
+
+    private DateTimeUtil() {
+        // Prevent instantiation
+    }
 
     /**
      * Returns true if a given string is a valid date.

--- a/src/test/java/seedu/address/commons/util/DateTimeUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/DateTimeUtilTest.java
@@ -1,14 +1,71 @@
 package seedu.address.commons.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.Test;
 
 class DateTimeUtilTest {
 
     @Test
-    void isValidDate() {
+    void checkValidDate_validDate_success() {
+        assertTrue(DateTimeUtil.isValidDate("01-01-2024 13:59"));
+        assertTrue(DateTimeUtil.isValidDate("31-12-2024 23:59"));
+        assertTrue(DateTimeUtil.isValidDate("29-02-2024 00:00"));
+
     }
 
     @Test
-    void parseDateTime() {
+    void checkValidDate_invalidFormat_failure() {
+        // dd-mm-yy HH:mm
+        assertFalse(DateTimeUtil.isValidDate("01-01-24 00:00"));
+        // mm-dd-yyyy HH:mm
+        assertFalse(DateTimeUtil.isValidDate("01-31-2024 00:00"));
+        // dd-mm HH:mm
+        assertFalse(DateTimeUtil.isValidDate("31-01 00:00"));
+        // yyyy-mm-dd HH:mm
+        assertFalse(DateTimeUtil.isValidDate("2024-01-31 00:00"));
+        // dd/mm/yyyy HH:mm
+        assertFalse(DateTimeUtil.isValidDate("31/01/2024 00:00"));
+        // dd-mm-yyyy HH:mm:ss
+        assertFalse(DateTimeUtil.isValidDate("01-01-2020 00:00:00"));
+        // dd-mm-yyyy
+        assertFalse(DateTimeUtil.isValidDate("01-01-2020"));
+    }
+
+    @Test
+    void checkValidDate_nonexistentDate_failure() {
+        // No leap year in 2023
+        assertFalse(DateTimeUtil.isValidDate("29-02-2023 00:00"));
+        // No 30-31st of February
+        assertFalse(DateTimeUtil.isValidDate("30-02-2024 00:00"));
+        assertFalse(DateTimeUtil.isValidDate("31-02-2024 00:00"));
+        // Mp 32nd of month
+        assertFalse(DateTimeUtil.isValidDate("32-01-2024 00:00"));
+        /// Invalid times
+        assertFalse(DateTimeUtil.isValidDate("01-01-2024 25:00"));
+        assertFalse(DateTimeUtil.isValidDate("01-01-2024 00:61"));
+        assertFalse(DateTimeUtil.isValidDate("01-01-2024 24:00"));
+    }
+
+
+    @Test
+    void formatDateTime_valid_success() {
+        LocalDateTime dateTime = LocalDateTime.of(2020, 1, 1, 13, 59);
+        assertEquals("01-01-2020 13:59", DateTimeUtil.formatDateTime(dateTime));
+    }
+
+    @Test
+    void parseDateTime_valid_success() {
+        LocalDateTime dateTime = LocalDateTime.of(2020, 1, 1, 13, 59);
+        assertEquals(dateTime, DateTimeUtil.parseDateTime("01-01-2020 13:59"));
+    }
+
+    @Test
+    void getCurrentTime_currentTime_success() {
+        assertEquals(DateTimeUtil.formatDateTime(LocalDateTime.now()), DateTimeUtil.getCurrentTime());
     }
 }


### PR DESCRIPTION
To note:
Changed formatter to use ResolverStyle.STRICT to prevent days beyond
 last day of month from being converted automatically to last valid day.

 29-02-2023 will no longer be converted automatically to 28-02-2023

@Jaspertzx take note of this change when checking that `deadline > now`