### PR TITLE
Fix Date Formatting

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -176,7 +176,7 @@ public class MainApp extends Application {
 
     @Override
     public void stop() {
-        logger.info("============================ [ Stopping Address Book ] =============================");
+        logger.info("============================ [ Stopping BookKeeper ] =============================");
         try {
             storage.saveUserPrefs(model.getUserPrefs());
         } catch (IOException e) {

--- a/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
@@ -63,7 +63,7 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DETAILS, PREFIX_BY, PREFIX_PRICE);
         OrderId orderId = new OrderId();
         OrderDate orderDate = new OrderDate(DateTimeUtil.getCurrentTime());
-        Deadline deadline = new Deadline(argMultimap.getValue(PREFIX_BY).get());
+        Deadline deadline = ParserUtil.parseDeadline(argMultimap.getValue(PREFIX_BY).get());
         Remark remark = new Remark(argMultimap.getValue(PREFIX_DETAILS).get());
         Price price = new Price(argMultimap.getValue(PREFIX_PRICE).get());
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -155,13 +155,12 @@ public class ParserUtil {
         String trimmedDeadline = deadline.trim();
         if (!Deadline.isValidDeadline(trimmedDeadline)) {
             throw new ParseException(Deadline.MESSAGE_CONSTRAINTS);
-        } else {
-            Deadline deadlineObj = new Deadline(trimmedDeadline);
-            if (!Deadline.isAfterCurrentDate(deadlineObj)) {
-                throw new ParseException(Deadline.INVALID_DATE_CONSTRAINTS);
-            }
-            return deadlineObj;
         }
+        Deadline deadlineObj = new Deadline(trimmedDeadline);
+        if (!Deadline.isAfterCurrentDate(deadlineObj)) {
+            throw new ParseException(Deadline.INVALID_DATE_CONSTRAINTS);
+        }
+        return deadlineObj;
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -156,7 +156,11 @@ public class ParserUtil {
         if (!Deadline.isValidDeadline(trimmedDeadline)) {
             throw new ParseException(Deadline.MESSAGE_CONSTRAINTS);
         } else {
-            return new Deadline(trimmedDeadline);
+            Deadline deadlineObj = new Deadline(trimmedDeadline);
+            if (!Deadline.isAfterCurrentDate(deadlineObj)) {
+                throw new ParseException(Deadline.INVALID_DATE_CONSTRAINTS);
+            }
+            return deadlineObj;
         }
     }
 

--- a/src/main/java/seedu/address/model/order/Deadline.java
+++ b/src/main/java/seedu/address/model/order/Deadline.java
@@ -17,6 +17,9 @@ public class Deadline implements Comparable<Deadline> {
             "A deadline should be in the format of "
                     + "DD-MM-YYYY HH:MM, e.g. 01-01-2024 23:59";
 
+    public static final String INVALID_DATE_CONSTRAINTS = "The deadline provided must be set for a time in the future "
+            + "and must not be before the current time.";
+
 
     public final LocalDateTime deadline;
 
@@ -31,12 +34,21 @@ public class Deadline implements Comparable<Deadline> {
         this.deadline = DateTimeUtil.parseDateTime(deadline);
     }
 
-
     /**
      * Returns true if a given string is a valid deadline.
+     * @returns boolean value to indicate true or false on the statement above.
      */
     public static boolean isValidDeadline(String test) {
         return DateTimeUtil.isValidDate(test);
+    }
+
+    /**
+     * Returns true if a given Date is after the current time.
+     * @return boolean value to indicate true or false on the statement above.
+     */
+    public static boolean isAfterCurrentDate(Deadline deadlineObj) {
+        LocalDateTime now = LocalDateTime.now();
+        return deadlineObj.deadline.isAfter(now);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddOrderCommandParserTest.java
@@ -15,6 +15,13 @@ import seedu.address.logic.commands.orders.AddOrderCommand;
 public class AddOrderCommandParserTest {
     private AddOrderCommandParser parser = new AddOrderCommandParser();
 
+    public static String getFutureDateForTest() {
+        LocalDateTime futureDate = LocalDateTime.now().plusDays(1);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm");
+        String futureDateString = futureDate.format(formatter);
+        return futureDateString;
+    }
+
     @Test
     public void parse_invalidCommandFormat_throwsParseException() {
         assertParseFailure(parser, "1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddOrderCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -95,7 +95,7 @@ public class AddressBookParserTest {
     public void parseCommand_createOrder() throws Exception {
         String remarks = " d/1xRoses";
         String cost = " c/100";
-        String date = " by/10-10-2024 00:00";
+        String date = " by/" + AddOrderCommandParserTest.getFutureDateForTest();
         assertTrue(parser.parseCommand(AddOrderCommand.COMMAND_WORD + " 1"
                 + remarks + cost + date) instanceof AddOrderCommand);
     }
@@ -113,7 +113,7 @@ public class AddressBookParserTest {
     public void parseCommand_editOrder() throws Exception {
         String remarks = " d/ 1xRoses";
         String price = " c/ 40";
-        String deadline = " by/ 23-07-2024 10:10";
+        String deadline = " by/ " + AddOrderCommandParserTest.getFutureDateForTest();
         String status = " s/ PENDING";
         assertTrue(parser.parseCommand(EditOrderCommand.COMMAND_WORD + " 1"
                 + deadline + price + remarks + status) instanceof EditOrderCommand);

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -46,7 +46,7 @@ public class ParserUtilTest {
     private static final String INVALID_PRICE = "ab";
     private static final String INVALID_REMARK = " ";
     private static final String INVALID_STATUS = "ALMOST";
-    private static final String VALID_DEADLINE = "23-07-2024 10:23";
+    private static final String VALID_DEADLINE = AddOrderCommandParserTest.getFutureDateForTest();
     private static final String VALID_PRICE = "40";
     private static final String VALID_REMARK = "1xRoses";
     private static final String VALID_STATUS = "PENDING";


### PR DESCRIPTION
Users can enter an invalid date, and no error message would show up.

This makes it confusing as they are left wondering why their commands is invalid.

Fix the date formatting to throw an error message on the output box for the users 
to see by ensuring that commands are using the parser method.

This will allow users to see the error.

Resolves #161
Resolves #165
Resolves #177
Resolves #170
Resolves #179
Resolves #198