### PR TITLE
Rename remark -> description

### DIFF
--- a/src/main/java/seedu/address/model/order/Remark.java
+++ b/src/main/java/seedu/address/model/order/Remark.java
@@ -8,7 +8,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents the remark of an order in the order book.
  */
 public class Remark {
-    public static final String MESSAGE_CONSTRAINTS = "Remark can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Description can take any values, and it should not be blank";
 
     /**
      * The first character of the remark must not be a whitespace,


### PR DESCRIPTION
Fixes #180

"Remark can take any values, and it should not be blank" changed to
"Description can take any values, and it should not be blank" 